### PR TITLE
Fix/right padding

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,26 +222,27 @@ VarSizeString.prototype.wrap = function (width, padding, process) {
   var hadLeftOver = false
   var currentPadding = padding.first
   var left
+  var right
   var remainingWidth = width
   var result = []
 
   function paddingRight () {
-    if (currentPadding.right && !/^\s*$/.test(currentPadding.right.string)) {
-      remainingWidth -= currentPadding.right.size()
-      if (remainingWidth > -1) {
-        result.push(new Array(remainingWidth + 2).join(' '))
+    if (right && !/^\s*$/.test(right.string)) {
+      if (remainingWidth > 0) {
+        result.push(new Array(remainingWidth + 1).join(' '))
       }
-      result.push(currentPadding.right.string)
+      result.push(right.string)
     }
   }
 
-  function paddingLeftInit () {
+  function paddingInit () {
     left = currentPadding.left
     if (left) {
       remainingWidth -= left.size()
     }
-    if (currentPadding.right) {
-      remainingWidth -= currentPadding.right.size()
+    right = currentPadding.right
+    if (right) {
+      remainingWidth -= right.size()
     }
   }
 
@@ -251,7 +252,7 @@ VarSizeString.prototype.wrap = function (width, padding, process) {
     hadLeftOver = false
     remainingWidth = width
     currentPadding = padding.regular
-    paddingLeftInit()
+    paddingInit()
   }
 
   function leftPad () {
@@ -261,7 +262,7 @@ VarSizeString.prototype.wrap = function (width, padding, process) {
     }
   }
 
-  paddingLeftInit()
+  paddingInit()
   this.getLines().forEach(function (line) {
     var lineWidth = line.size()
     var lineOffset = 0
@@ -287,15 +288,15 @@ VarSizeString.prototype.wrap = function (width, padding, process) {
       }
       nextLine()
     }
-    var content = line.substring(lineOffset).string.replace(/^\s+|\s+$/g, '')
+    var content = line.substring(lineOffset)
     if (hadLeftOver) {
       result.push(sep)
       remainingWidth -= sepLength
     }
     leftPad()
-    result.push(content)
+    result.push(content.string.replace(/^\s+|\s+$/g, ''))
     hadLeftOver = true
-    remainingWidth -= (lineWidth - lineOffset)
+    remainingWidth -= content.size
     return result
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -190,6 +190,7 @@ test('wrapping with padding', function (t) {
   t.equal(wrap('abcd', 6, {left: '_', right: '-'}), '_abcd-', 'different paddings left and right')
   t.equal(wrap('abcd', 6, {left: '_'}), '_abcd', 'missing right assumes right to be empty string')
   t.equal(wrap('abcd', 6, {right: '_'}), 'abcd _', 'missing left assumes left to be empty string')
+  t.equal(wrap('abcddefgh', 7, {left: '_ ', right: '_'}), '_ abcd_\n_ defg_\n_ h   _', 'breaks with padding assume correct wrapping with right characters')
   t.equal(wrap('abcdef', 4, {first: 'x', regular: '-'}), 'xabc\n-def', 'different paddings in first and following rows')
   t.equal(wrap('abcdefgh', 4, {first: '--', regular: '-'}), '--ab\n-cde\n-fgh', 'different padding size in first and following rows')
   t.equal(wrap('abcdefgh', 4, {

--- a/test/index.js
+++ b/test/index.js
@@ -191,6 +191,7 @@ test('wrapping with padding', function (t) {
   t.equal(wrap('abcd', 6, {left: '_'}), '_abcd', 'missing right assumes right to be empty string')
   t.equal(wrap('abcd', 6, {right: '_'}), 'abcd _', 'missing left assumes left to be empty string')
   t.equal(wrap('abcddefgh', 7, {left: '_ ', right: '_'}), '_ abcd_\n_ defg_\n_ h   _', 'breaks with padding assume correct wrapping with right characters')
+  t.equal(wrap('abcddefgh\nabcd', 7, {left: '_ ', right: '_'}), '_ abcd_\n_ defg_\n_ h   _\n_ abcd_', 'breaks with padding assume correct wrapping with right characters and new line')
   t.equal(wrap('abcdef', 4, {first: 'x', regular: '-'}), 'xabc\n-def', 'different paddings in first and following rows')
   t.equal(wrap('abcdefgh', 4, {first: '--', regular: '-'}), '--ab\n-cde\n-fgh', 'different padding size in first and following rows')
   t.equal(wrap('abcdefgh', 4, {


### PR DESCRIPTION
The right padding was broken, resulting in too-wide strings after the second line of a list. This PR fixes that.
